### PR TITLE
Renaming solusio to SOLUSIO in cloud_id for Plesk images

### DIFF
--- a/scripts/plesk/install_plesk.sh
+++ b/scripts/plesk/install_plesk.sh
@@ -155,7 +155,7 @@ esac
 
 tempkey_rollback
 
-echo "solusio" > $psa_d/var/cloud_id
+echo "SOLUSIO" > $psa_d/var/cloud_id
 /usr/local/psa/admin/sbin/nginxmng -d
 /usr/local/psa/admin/sbin/nginxmng -e
 


### PR DESCRIPTION
Just to make it similar for any other cloud_id used in/with Plesk