### PR TITLE
Bump plesk version to 18.0.37 and fix preseed files for debian & ubuntu

### DIFF
--- a/almalinux/solus-almalinux-8-plesk.json
+++ b/almalinux/solus-almalinux-8-plesk.json
@@ -68,7 +68,7 @@
       "environment_vars": [
         "IS_SOLUS=true",
         "INSTALL_BYOL=true",
-        "INSTALL_PLESK_VERSION=18.0.36",
+        "INSTALL_PLESK_VERSION=18.0.37",
         "INSTALL_PLESK_PRESET=Recommended",
         "INSTALL_WITH_PLESK_COMPONENTS=",
         "INSTALL_WITHOUT_PLESK_COMPONENTS=",

--- a/centos/solus-centos-7-plesk.json
+++ b/centos/solus-centos-7-plesk.json
@@ -71,7 +71,7 @@
       "environment_vars": [
         "IS_SOLUS=true",
         "INSTALL_BYOL=true",
-        "INSTALL_PLESK_VERSION=18.0.36",
+        "INSTALL_PLESK_VERSION=18.0.37",
         "INSTALL_PLESK_PRESET=Recommended",
         "INSTALL_WITH_PLESK_COMPONENTS=",
         "INSTALL_WITHOUT_PLESK_COMPONENTS=",

--- a/centos/solus-centos-8-plesk.json
+++ b/centos/solus-centos-8-plesk.json
@@ -2,7 +2,7 @@
   "variables": {
     "user": "centos",
     "password": "centos",
-    "disk_size": "6000",
+    "disk_size": "9000",
     "output_directory": "output/centos",
     "output_image_name": "solus-io-centos-8-plesk"
   },
@@ -70,7 +70,7 @@
       "environment_vars": [
         "IS_SOLUS=true",
         "INSTALL_BYOL=true",
-        "INSTALL_PLESK_VERSION=18.0.36",
+        "INSTALL_PLESK_VERSION=18.0.37",
         "INSTALL_PLESK_PRESET=Recommended",
         "INSTALL_WITH_PLESK_COMPONENTS=",
         "INSTALL_WITHOUT_PLESK_COMPONENTS=",

--- a/debian/http/preseed-debian-10.cfg
+++ b/debian/http/preseed-debian-10.cfg
@@ -3,12 +3,12 @@
 d-i debian-installer/locale string en_US
 d-i debian-installer/language string en
 d-i debian-installer/country string US
+d-i debian-installer/locale string en_US.UTF-8
 d-i localechooser/supported-locales multiselect en_US.UTF-8
 
 # Keyboard selection.
-d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/xkb-keymap select us
-d-i keyboard-configuration/layoutcode string us
+# d-i keyboard-configuration/toggle select No toggling
 
 ### Network configuration
 # netcfg will choose an interface that has link if possible. This makes it
@@ -22,26 +22,25 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string manual
-
-# any host here will be replaced to archive.ubuntu.com by cloud-init
-d-i mirror/http/hostname string archive.ubuntu.com
-
-d-i mirror/http/directory string /ubuntu
+d-i mirror/http/hostname string cdn.debian.net
+d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i mirror/suite string focal
+d-i mirror/suite string buster
+
+### Apt setup
+d-i apt-setup/non-free boolean true
+d-i apt-setup/contrib boolean true
+d-i apt-setup/services-select multiselect security, volatile
+d-i apt-setup/security_host string security.debian.org
+d-i apt-setup/volatile_host string volatile.debian.org
 
 ### Account setup
-# Skip creation of a root account (normal user account will be able to
-# use sudo).
-#d-i passwd/root-login boolean false
-d-i passwd/root-login boolean false
-d-i passwd/root-password-again password ubuntu
-d-i passwd/root-password password ubuntu
-d-i passwd/user-fullname string ubuntu
-d-i passwd/user-uid string 1000
-d-i passwd/user-password password ubuntu
-d-i passwd/user-password-again password ubuntu
-d-i passwd/username string ubuntu
+# Allow root to login
+d-i passwd/root-login boolean true
+# Skip creation of a normal user account.
+d-i passwd/make-user boolean false
+d-i passwd/root-password-again password root
+d-i passwd/root-password password root
 d-i user-setup/allow-password-weak boolean true
 
 ### Clock and time zone setup
@@ -73,12 +72,15 @@ d-i partman-auto/method string regular
 # - atomic: all files in one partition
 # - home:   separate /home partition
 # - multi:  separate /home, /var, and /tmp partitions
+
+d-i partman-basicfilesystems/no_swap boolean false
 d-i partman-auto/expert_recipe string root :: \
-    2500 50 8500 ext4 \
+    1000 50 -1 xfs \
         $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ ext4 } \
+        format{ } use_filesystem{ } filesystem{ xfs } \
         mountpoint{ / } \
     .
+d-i partman-auto/choose_recipe select root
 
 # This makes partman automatically partition without confirmation, provided
 # that you told it what to do using one of the methods above.
@@ -87,14 +89,19 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 
+# Skip CD scan
+d-i apt-setup/cdrom/set-first boolean false
+d-i apt-setup/cdrom/set-next boolean false
+d-i apt-setup/cdrom/set-failed boolean false
+
 ### Package selection
-tasksel tasksel/first multiselect ubuntu-server
+tasksel tasksel/first multiselect ssh-server
+
 # Individual additional packages to install
 #d-i pkgsel/include string openssh-sever build-essential
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade
-d-i pkgsel/include string openssh-server ssh sudo wget curl
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/include string openssh-server ssh sudo wget curl cloud-init cloud-utils qemu-guest-agent
 d-i pkgsel/upgrade select safe-upgrade
 # Some versions of the installer can report back on what software you have
 # installed, and what software you use. The default is not to report back,
@@ -117,13 +124,12 @@ d-i grub-installer/with_other_os boolean true
 # To install to the first device (assuming it is not a USB stick):
 d-i grub-installer/bootdev  string default
 
-d-i preseed/late_command string                                 \
-				echo 'Defaults:ubuntu !requiretty' > /target/etc/sudoers.d/ubuntu; \
-				echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' >> /target/etc/sudoers.d/ubuntu; \
-				chmod 440 /target/etc/sudoers.d/ubuntu; \
-in-target update-initramfs -u
+#d-i preseed/late_command string                                 \
+#				echo 'Defaults:debian !requiretty' > /target/etc/sudoers.d/debian; \
+#				echo 'debian ALL=(ALL) NOPASSWD: ALL' >> /target/etc/sudoers.d/debian; \
+#				chmod 440 /target/etc/sudoers.d/debian; \
+d-i preseed/late_command string sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /target/etc/ssh/sshd_config
 
 ### Finishing up the installation
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note
-d-i cdrom-detect/eject boolean false

--- a/debian/http/preseed-debian-11.cfg
+++ b/debian/http/preseed-debian-11.cfg
@@ -3,12 +3,12 @@
 d-i debian-installer/locale string en_US
 d-i debian-installer/language string en
 d-i debian-installer/country string US
+d-i debian-installer/locale string en_US.UTF-8
 d-i localechooser/supported-locales multiselect en_US.UTF-8
 
 # Keyboard selection.
-d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/xkb-keymap select us
-d-i keyboard-configuration/layoutcode string us
+# d-i keyboard-configuration/toggle select No toggling
 
 ### Network configuration
 # netcfg will choose an interface that has link if possible. This makes it
@@ -22,26 +22,25 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string manual
-
-# any host here will be replaced to archive.ubuntu.com by cloud-init
-d-i mirror/http/hostname string archive.ubuntu.com
-
-d-i mirror/http/directory string /ubuntu
+d-i mirror/http/hostname string cdn.debian.net
+d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i mirror/suite string focal
+d-i mirror/suite string bullseye
+
+### Apt setup
+d-i apt-setup/non-free boolean true
+d-i apt-setup/contrib boolean true
+d-i apt-setup/services-select multiselect security, volatile
+d-i apt-setup/security_host string security.debian.org
+d-i apt-setup/volatile_host string volatile.debian.org
 
 ### Account setup
-# Skip creation of a root account (normal user account will be able to
-# use sudo).
-#d-i passwd/root-login boolean false
-d-i passwd/root-login boolean false
-d-i passwd/root-password-again password ubuntu
-d-i passwd/root-password password ubuntu
-d-i passwd/user-fullname string ubuntu
-d-i passwd/user-uid string 1000
-d-i passwd/user-password password ubuntu
-d-i passwd/user-password-again password ubuntu
-d-i passwd/username string ubuntu
+# Allow root to login
+d-i passwd/root-login boolean true
+# Skip creation of a normal user account.
+d-i passwd/make-user boolean false
+d-i passwd/root-password-again password root
+d-i passwd/root-password password root
 d-i user-setup/allow-password-weak boolean true
 
 ### Clock and time zone setup
@@ -73,12 +72,15 @@ d-i partman-auto/method string regular
 # - atomic: all files in one partition
 # - home:   separate /home partition
 # - multi:  separate /home, /var, and /tmp partitions
+
+d-i partman-basicfilesystems/no_swap boolean false
 d-i partman-auto/expert_recipe string root :: \
-    2500 50 8500 ext4 \
+    1000 50 -1 xfs \
         $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ ext4 } \
+        format{ } use_filesystem{ } filesystem{ xfs } \
         mountpoint{ / } \
     .
+d-i partman-auto/choose_recipe select root
 
 # This makes partman automatically partition without confirmation, provided
 # that you told it what to do using one of the methods above.
@@ -87,14 +89,19 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 
+# Skip CD scan
+d-i apt-setup/cdrom/set-first boolean false
+d-i apt-setup/cdrom/set-next boolean false
+d-i apt-setup/cdrom/set-failed boolean false
+
 ### Package selection
-tasksel tasksel/first multiselect ubuntu-server
+tasksel tasksel/first multiselect ssh-server
+
 # Individual additional packages to install
 #d-i pkgsel/include string openssh-sever build-essential
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade
-d-i pkgsel/include string openssh-server ssh sudo wget curl
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/include string openssh-server ssh sudo wget curl cloud-init cloud-utils qemu-guest-agent
 d-i pkgsel/upgrade select safe-upgrade
 # Some versions of the installer can report back on what software you have
 # installed, and what software you use. The default is not to report back,
@@ -117,13 +124,12 @@ d-i grub-installer/with_other_os boolean true
 # To install to the first device (assuming it is not a USB stick):
 d-i grub-installer/bootdev  string default
 
-d-i preseed/late_command string                                 \
-				echo 'Defaults:ubuntu !requiretty' > /target/etc/sudoers.d/ubuntu; \
-				echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' >> /target/etc/sudoers.d/ubuntu; \
-				chmod 440 /target/etc/sudoers.d/ubuntu; \
-in-target update-initramfs -u
+#d-i preseed/late_command string                                 \
+#				echo 'Defaults:debian !requiretty' > /target/etc/sudoers.d/debian; \
+#				echo 'debian ALL=(ALL) NOPASSWD: ALL' >> /target/etc/sudoers.d/debian; \
+#				chmod 440 /target/etc/sudoers.d/debian; \
+d-i preseed/late_command string sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /target/etc/ssh/sshd_config
 
 ### Finishing up the installation
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note
-d-i cdrom-detect/eject boolean false

--- a/debian/http/preseed-debian-8.cfg
+++ b/debian/http/preseed-debian-8.cfg
@@ -75,11 +75,11 @@ d-i partman-auto/method string regular
 
 d-i partman-basicfilesystems/no_swap boolean false
 d-i partman-auto/expert_recipe string root :: \
-    1000 50 -1 xfs \
-        $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ xfs } \
-        mountpoint{ / } \
-    .
+                                            1000 50 -1 xfs \
+                                            $primary{ } $bootable{ } method{ format } \
+                                            format{ } use_filesystem{ } filesystem{ xfs } \
+                                            mountpoint{ / } \
+                                            .
 d-i partman-auto/choose_recipe select root
 
 # This makes partman automatically partition without confirmation, provided

--- a/debian/solus-debian-10.json
+++ b/debian/solus-debian-10.json
@@ -42,7 +42,7 @@
 			"boot_command": [
 				"<esc><wait>",
 				"install <wait>",
-				" preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+				" preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed-debian-10.cfg ",
 				"debian-installer=en_US.UTF-8 <wait>",
 				"auto <wait>",
 				"locale=en_US.UTF-8 <wait>",

--- a/debian/solus-debian-11.json
+++ b/debian/solus-debian-11.json
@@ -42,7 +42,7 @@
 			"boot_command": [
 				"<esc><wait>",
 				"install <wait>",
-				" preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+				" preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed-debian-11.cfg ",
 				"debian-installer=en_US.UTF-8 <wait>",
 				"auto <wait>",
 				"locale=en_US.UTF-8 <wait>",

--- a/debian/solus-debian-8.json
+++ b/debian/solus-debian-8.json
@@ -42,7 +42,7 @@
 			"boot_command": [
 				"<esc><wait>",
 				"install <wait>",
-				" preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+				" preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed-debian-8.cfg ",
 				"debian-installer=en_US.UTF-8 <wait>",
 				"auto <wait>",
 				"locale=en_US.UTF-8 <wait>",

--- a/ubuntu/solus-ubuntu-18-plesk.json
+++ b/ubuntu/solus-ubuntu-18-plesk.json
@@ -88,7 +88,7 @@
       "environment_vars": [
         "IS_SOLUS=true",
         "INSTALL_BYOL=true",
-        "INSTALL_PLESK_VERSION=18.0.36",
+        "INSTALL_PLESK_VERSION=18.0.37",
         "INSTALL_PLESK_PRESET=Recommended",
         "INSTALL_WITH_PLESK_COMPONENTS=",
         "INSTALL_WITHOUT_PLESK_COMPONENTS=",

--- a/ubuntu/solus-ubuntu-20-plesk.json
+++ b/ubuntu/solus-ubuntu-20-plesk.json
@@ -2,7 +2,7 @@
   "variables": {
     "user": "ubuntu",
     "password": "ubuntu",
-    "disk_size": "9000",
+    "disk_size": "10000",
     "output_directory": "output/ubuntu",
     "output_image_name": "solus-io-ubuntu-20-plesk"
   },
@@ -88,7 +88,7 @@
       "environment_vars": [
         "IS_SOLUS=true",
         "INSTALL_BYOL=true",
-        "INSTALL_PLESK_VERSION=18.0.36",
+        "INSTALL_PLESK_VERSION=18.0.37",
         "INSTALL_PLESK_PRESET=Recommended",
         "INSTALL_WITH_PLESK_COMPONENTS=",
         "INSTALL_WITHOUT_PLESK_COMPONENTS=",


### PR DESCRIPTION
Apart from making Plesk version actual I have replaced `bionic` with `focal` for repository mirrors at preseed-ubuntu-20.cfg file. 

Additionally, I have separated preseed files for different debian releases and adjusted the repository mirrors in the same way as for ubuntu.