### PR TITLE
BUGFIX SIO-3686 VZ containers can't be created on OpenVZ image becaus…

### DIFF
--- a/openvz/data/ks.cfg
+++ b/openvz/data/ks.cfg
@@ -18,7 +18,7 @@ clearpart --all --initlabel
 part biosboot  --fstype=biosboot --size=1
 part /boot     --asprimary --fstype=ext4 --label BOOT --size=500
 part /boot/efi --asprimary --fstype=vfat --label EFI  --size=200
-part /         --size=1 --grow --label=root --fsoptions="defaults,noatime,nodiratime" --fstype="xfs" --asprimary
+part /         --size=1 --grow --label=root --fsoptions="defaults,noatime,nodiratime" --fstype="ext4" --asprimary
 
 auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled


### PR DESCRIPTION
…e root file system with /vz folder has xfs instead of ext4 file system type